### PR TITLE
Added a prefix to the Mett notice

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func (bot *Mettbot) PostMett(channel string) {
 			return
 		}
 	}
-	mettnotice = "It's time for moar Mett: " + mett
+	mettnotice := "It's time for moar Mett: " + mett
 	bot.Notice(channel, mettnotice)
 }
 


### PR DESCRIPTION
The string `"It's time for moar Mett: "` will be posted before the mett content. Not tested!
